### PR TITLE
fix: remove '/graphql' from env NEXT_PUBLIC_API_URL

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_API_URL=http://localhost:1337/graphql
+NEXT_PUBLIC_API_URL=http://localhost:1337
 NEXT_PUBLIC_DATABASE_URL=postgres://strapi:strapi@localhost:5432/strapi?synchronize=true
 NEXTAUTH_URL=http://localhost:3000
 GOOGLE_CLIENT_ID=""

--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ cd backend
 docker-compose up
 ```
 
-We need to start Docker and then run the above command which will change the current directory to the backend package’s directory and then start the backend package. If everything goes well, it’ll be up and running on [http://localhost:1337/v1/graphql](http://localhost:1337/v1/graphql).
+We need to start Docker and then run the above command which will change the current directory to the backend package’s directory and then start the backend package. If everything goes well, it’ll be up and running on [http://localhost:1337/graphql](http://localhost:1337/graphql).
 
 ### 8. **Configure Strapi**
 


### PR DESCRIPTION
Otherwise it breaks on https://github.com/ghoshnirmalya/nextjs-strapi-boilerplate/blob/a4760c9ba3fda3e84449f59a0029a524129bf53a/frontend/pages/api/auth/%5B...nextauth%5D.ts#L33

Because /graphql/auth won't work...