### PR TITLE
Error when the feed has no author

### DIFF
--- a/frontend/components/pages/feeds/feed.tsx
+++ b/frontend/components/pages/feeds/feed.tsx
@@ -23,9 +23,9 @@ const Feed: FC<IProps> = ({ feed }) => {
         borderBottomWidth={1}
         borderColor={borderColor[colorMode]}
       >
-        <Avatar name={feed.author.username} />
+      <Avatar name={feed.author === null ? "anonymous" : feed.author.username} />
         <Stack>
-          <Text fontWeight="bold">{feed.author.username}</Text>
+          <Text fontWeight="bold">{feed.author === null ? "anonymous" : feed.author.username}</Text>
           <Text>{timeFromNow(feed.created_at)}</Text>
         </Stack>
       </Stack>


### PR DESCRIPTION
### Problem:
Type Error: feed author is null.

Source in folder components/pages/feeds/feed.tsx (26:16)

![feed-author-is-null](https://user-images.githubusercontent.com/15263927/92333221-2ab98b00-f0ae-11ea-8c53-e8a867d868c4.png)

### Solution:
Added the conditional statement "if the feed has no author, then it will be the anonymous".

Maybe there's a better way, but it fixed the error.

Thank you for creating this boilerplate.