### PR TITLE
Bump next-auth from 3.29.0 to 4.0.6

### DIFF
--- a/frontend/components/access-denied-indicator/index.tsx
+++ b/frontend/components/access-denied-indicator/index.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import { Icon, Flex, Button, Stack, Box } from "@chakra-ui/core";
 import Link from "next/link";
-import { signIn } from "next-auth/client";
+import { signIn } from "next-auth/react";
 
 interface IProps {
   message?: string;

--- a/frontend/components/navbar/index.tsx
+++ b/frontend/components/navbar/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { NextComponentType } from "next";
 import Link from "next/link";
-import { signIn, signOut, useSession } from "next-auth/client";
+import { signIn, signOut, useSession } from "next-auth/react";
 import {
   Box,
   Stack,
@@ -12,7 +12,7 @@ import {
 } from "@chakra-ui/core";
 
 const Navbar: NextComponentType = () => {
-  const [session] = useSession();
+  const { data:session, status } = useSession();
   const { colorMode, toggleColorMode } = useColorMode();
   const bgColor = { light: "white", dark: "gray.800" };
   const color = { light: "gray.800", dark: "gray.100" };

--- a/frontend/components/pages/feeds/add-new-feed-form.tsx
+++ b/frontend/components/pages/feeds/add-new-feed-form.tsx
@@ -13,7 +13,7 @@ import {
   Textarea,
   useColorMode,
 } from "@chakra-ui/core";
-import { useSession } from "next-auth/client";
+import { useSession } from "next-auth/react";
 import AccessDeniedIndicator from "components/access-denied-indicator";
 
 const insertFeedMutation = gql`
@@ -32,7 +32,7 @@ const AddNewFeedForm = () => {
   const bgColor = { light: "white", dark: "gray.800" };
   const color = { light: "gray.800", dark: "gray.100" };
   const [body, setBody] = useState("");
-  const [session] = useSession();
+  const { data:session, status } = useSession();
 
   if (!session) {
     return (

--- a/frontend/components/pages/index/index.tsx
+++ b/frontend/components/pages/index/index.tsx
@@ -8,11 +8,11 @@ import {
   Flex,
   useColorMode,
 } from "@chakra-ui/core";
-import { signIn, signOut, useSession } from "next-auth/client";
+import { signIn, signOut, useSession } from "next-auth/react";
 import Link from "next/link";
 
 const IndexPageComponent = () => {
-  const [session] = useSession();
+  const { data:session, status } = useSession();
   const heightOfNavbar: string = "74px";
   const containerPadding: string = "1rem";
   const { colorMode } = useColorMode();

--- a/frontend/components/pages/my-account/index.tsx
+++ b/frontend/components/pages/my-account/index.tsx
@@ -15,7 +15,7 @@ import {
   useColorMode,
 } from "@chakra-ui/core";
 import Loader from "components/loader";
-import { useSession } from "next-auth/client";
+import { useSession } from "next-auth/react";
 import React, { FormEvent, useEffect, useState } from "react";
 
 const usersQuery = gql`
@@ -45,7 +45,7 @@ const MyAccountPageComponent = () => {
   const bgColor = { light: "white", dark: "gray.800" };
   const color = { light: "gray.800", dark: "gray.100" };
   const [username, setUsername] = useState("");
-  const [session] = useSession();
+  const { data:session, status } = useSession();
 
   const {
     loading: fetchUserFetching,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "emotion-theming": "^10.3.0",
     "graphql": "^16.2.0",
     "next": "^12.0.7",
-    "next-auth": "^3.29.0",
+    "next-auth": "^4.0.6",
     "pg": "^8.7.1",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AppProps } from "next/app";
 import Head from "next/head";
-import { Provider as NextAuthProvider } from "next-auth/client";
+import { SessionProvider  } from "next-auth/react";
 import { ThemeProvider, CSSReset, theme } from "@chakra-ui/core";
 import Layout from "components/layout";
 
@@ -13,14 +13,14 @@ const App = ({ Component, pageProps }: AppProps) => {
       <Head>
         <link rel="shortcut icon" href="/images/favicon.ico" />
       </Head>
-      <NextAuthProvider session={session}>
+      <SessionProvider session={session}>
         <ThemeProvider theme={theme}>
           <CSSReset />
           <Layout>
             <Component {...pageProps} />
           </Layout>
         </ThemeProvider>
-      </NextAuthProvider>
+      </SessionProvider>
     </>
   );
 };

--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import NextAuth from "next-auth";
-import Providers from "next-auth/providers";
+import GoogleProvider from "next-auth/providers/google";
 import IAccount from "types/account";
 import iToken from "types/token";
 import IUser from "types/user";
@@ -8,40 +8,17 @@ import ISession from "types/session";
 
 const options = {
   providers: [
-    Providers.Google({
+    GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
     }),
   ],
+  secret:"5xT45s7AKNuQREg7gF9LoQSXwW/dL62hAEKKfk/rk8k=", //PUT YOUR OWN SECRET (command: openssl rand -base64 32)
   database: process.env.NEXT_PUBLIC_DATABASE_URL,
   session: {
-    jwt: true,
+    strategy: "jwt",
   },
   debug: true,
-  callbacks: {
-    session: async (session: ISession, user: IUser) => {
-      session.jwt = user.jwt;
-      session.id = user.id;
-
-      return Promise.resolve(session);
-    },
-    jwt: async (token: iToken, user: IUser, account: IAccount) => {
-      const isSignIn = user ? true : false;
-
-      if (isSignIn) {
-        const response = await fetch(
-          `${process.env.NEXT_PUBLIC_API_URL}/auth/${account.provider}/callback?access_token=${account?.accessToken}`
-        );
-
-        const data = await response.json();
-
-        token.jwt = data.jwt;
-        token.id = data.user.id;
-      }
-
-      return Promise.resolve(token);
-    },
-  },
 };
 
 const Auth = (req: NextApiRequest, res: NextApiResponse) =>

--- a/frontend/pages/feeds.tsx
+++ b/frontend/pages/feeds.tsx
@@ -3,7 +3,7 @@ import Head from "next/head";
 import Page from "components/pages/feeds";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import AccessDeniedIndicator from "components/access-denied-indicator";
-import { getSession } from "next-auth/client";
+import { getSession } from "next-auth/react";
 import WithGraphQL from "lib/with-graphql";
 
 const FeedsPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({

--- a/frontend/pages/my-account.tsx
+++ b/frontend/pages/my-account.tsx
@@ -3,7 +3,7 @@ import Head from "next/head";
 import Page from "components/pages/my-account";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import AccessDeniedIndicator from "components/access-denied-indicator";
-import { getSession } from "next-auth/client";
+import { getSession } from "next-auth/react";
 import WithGraphQL from "lib/with-graphql";
 
 const MyAccountPage: InferGetServerSidePropsType<typeof getServerSideProps> = ({

--- a/frontend/vendor.d.ts
+++ b/frontend/vendor.d.ts
@@ -1,3 +1,3 @@
-declare module "next-auth/client";
+declare module "next-auth/react";
 declare module "next-auth";
 declare module "next-auth/providers";


### PR DESCRIPTION
This project is associated with step-by-step article and it can't be reproducible because next-auth v4 is GA now.
The change includes all migration efforts from v3 to v4 based on [official migration document](https://next-auth.js.org/getting-started/upgrade-v4).

One thing to be mentioned in the article is to generate a new secret, which is mandated in next-auth v4.