### PR TITLE
change working directory to /app

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,16 +1,18 @@
 FROM strapi/base
 
-COPY ./app/package.json ./
-COPY ./app/yarn.lock ./
+WORKDIR /app
+
+COPY ./app/package.json /app/package.json
+COPY ./app/yarn.lock /app/yarn.lock
 
 RUN yarn install
 
-COPY ./app .
+COPY ./app /app/
 
-ENV NODE_ENV production
+ENV NODE_ENV development
 
 RUN yarn build
 
 EXPOSE 1337
 
-CMD ["yarn", "start"]
+CMD ["yarn", "develop"]


### PR DESCRIPTION
Running strapi with `starpi develop` gives access to its full capabilities like adding content type from the admin dashboard but having root the as working directory causes issues, at least on windows wsl. [Found the fix here](https://stackoverflow.com/a/47383952/13035510)